### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To get started deploying your app we recommend making an account on [Vercel](htt
 
 By default, the Foo Medical Provider app uses a shared project.
 
-To use your own organization with Foo Medical Provider you will need to [register a new Project on Medplum](https://docs.medplum.com/tutorials/app/register) and replace the `projectId` on the [sign in page](https://github.com/rahul1/foomedical-provider/blob/main/src/pages/SignInPage.tsx#L10) with your new projectId.
+To use your own organization with Foo Medical Provider you will need to [register a new Project on Medplum](https://www.medplum.com/docs/tutorials/register) and replace the `projectId` on the [sign in page](https://github.com/rahul1/foomedical-provider/blob/main/src/pages/SignInPage.tsx#L10) with your new projectId.
 
 To enable Google Authentication, you will have to set the following values on your [Project's Site Settings](https://app.medplum.com/admin/sites)
 
@@ -74,7 +74,7 @@ To enable Google Authentication, you will have to set the following values on yo
 - Recaptcha Site Key
 - Recaptcha Secret Key
 
-Contact the medplum team ([support@medplum.com](mailto:support@medplum.com) or [Discord](https://discord.gg/UBAWwvrVeN])) with any questions.
+Contact the Medplum team ([support@medplum.com](mailto:support@medplum.com) or [Discord](https://discord.gg/UBAWwvrVeN)) with any questions.
 
 ### Compliance
 


### PR DESCRIPTION
**Problem**: Fixed a broken link under Account Setup for registering a new product, as well as one broken link to the Medplum Discord channel.
<img width="746" alt="Screen Shot 2022-12-08 at 3 10 16 PM" src="https://user-images.githubusercontent.com/56564279/206596493-b7a11cc2-f760-4c82-939a-d8e53d8e3f6b.png">
<img width="671" alt="Screen Shot 2022-12-08 at 3 23 35 PM" src="https://user-images.githubusercontent.com/56564279/206596509-4e1563d7-ee65-46ed-a2ca-248dc2c5694e.png">

**Solution**: Updated link for Medplum registration to new url, and removed an errant character for the Discord.

**Start**: README.me

**Verified**: Links work as expected now.
<img width="769" alt="Screen Shot 2022-12-08 at 4 47 16 PM" src="https://user-images.githubusercontent.com/56564279/206597254-9db63541-b00c-4950-af4d-3bbae181895f.png">
