### PR TITLE
Add testing for PatientsList

### DIFF
--- a/src/pages/PatientsList.test.tsx
+++ b/src/pages/PatientsList.test.tsx
@@ -1,0 +1,85 @@
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import crypto from 'crypto';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { TextEncoder } from 'util';
+import { PatientsList } from './PatientsList';
+
+async function setup(url='/patients', medplum = new MockClient()): Promise<void> {
+  await act(async() => {
+    render(
+      <MemoryRouter
+        initialEntries={[url]} initialIndex={0}>
+        <MedplumProvider medplum={medplum}>
+          <PatientsList />
+        </MedplumProvider>
+      </MemoryRouter>
+    );
+  })
+}
+
+describe('Patients list', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  beforeAll(() => {
+    Object.defineProperty(global, 'TextEncoder', {
+      value: TextEncoder,
+    });
+
+    Object.defineProperty(global.self, 'crypto', {
+      value: crypto.webcrypto,
+    });
+  });
+
+  test('Patients header', async () => {
+    await setup();
+
+    expect(screen.getByRole('heading', { name: 'Patients' })).toBeInTheDocument;
+  });
+  
+  test('Name table header', async () => {
+    await setup();
+
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
+  });
+  
+  test('DoB table header', async () => {
+    await setup();
+
+    expect(screen.getByRole('columnheader', { name: 'DoB' })).toBeInTheDocument();
+  });
+  
+  test('Email table header', async () => {
+    await setup();
+
+    expect(screen.getByRole('columnheader', { name: 'Email' })).toBeInTheDocument();
+  });
+
+  
+  test('Renders "New" button', async () => {
+    await setup();
+    const newButton = screen.getByRole('button', { name: 'New' });
+
+    expect(newButton).toBeInTheDocument();
+  });
+  
+  test('Renders "Import" button', async () => {
+    await setup();
+    const importButton = screen.getByRole('button', { name: 'Import' });
+    
+    expect(importButton).toBeInTheDocument();
+  });
+  
+  test('Renders "View" button', async () => {
+    await setup();
+    const viewButton = screen.getAllByRole('button', { name: 'View' })[0];
+
+    fireEvent.click(viewButton);
+
+    expect(viewButton).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
**Problem**: There are no tests set up for Foo Medical Provider's Patients (`'/patients'`) page to verify page elements work as intended.

**Solution**: Added basic UI testing for Patients tab to validate elements render as expected using Medplum app tests as a guide for what to cover.

**Start**: `PatientsList.test.tsx`

**Verified**: Test suite runs with seven tests passing as intended.
![Screenshot 2023-01-23 at 5 13 24 PM](https://user-images.githubusercontent.com/56564279/214192927-f15195e6-ebb3-4054-9620-0f0793415a59.png)

**Requirements**: If haven't already, run `npm install` (or `npm i`) for testing setup. Following testing setup, run `npm run test` (or `npm t`) to validate tests.

**Not in scope**: Verifying elements that involve mock data or FHIR operation requests. To come.